### PR TITLE
Fix scope of cursor transparency so that cursor is visible for non-CodeMirror lines

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,13 @@ id: kotaindah55-animated-cursor
 settings:
 
 	-
+		id: cursor-thickness
+		title: Cursor thickness
+		description: The thickness of the cursor in pixels
+		type: variable-number
+		format: px
+		default: 2
+	-
 		id: cursor-move-speed
 		title: Cursor speed
 		description: The speed of each cursor movement in miliseconds.
@@ -29,7 +36,19 @@ settings:
 		title: Infinity blinking
 		description: Whether the blinking is infinity. When turned on, "Blink count" setting doesn't have any effect.
 		type: class-toggle
-
+	-
+		id: cursor-override-color
+		title: Change cursor color
+		description: Override the default cursor color
+		type: class-toggle
+	- 
+		id: cursor-color
+		title: Cursor color
+		type: variable-themed-color
+		format: hex
+		opacity: true
+		default-light: '#222222'
+		default-dark: '#dadada'
 */
 
 :root {
@@ -38,18 +57,19 @@ settings:
 	--cursor-blink-rate: 1000ms;
 	--cursor-blink-count: 10;
 	--cursor-blink-easing: ease-in-out;
+	--cursor-width: 2px;
 }
 
 @keyframes cm-cursor-blink {
-	0%, 40% {
+	0%, 30% {
 		opacity: 0;
 	}
-	80%, 100% {
+	70%, 100% {
 		opacity: 1;
 	}
 }
 
-.markdown-source-view.mod-cm6 .cm-content {
+.markdown-source-view.mod-cm6 .cm-content .cm-line {
 	caret-color: transparent;
 }
 
@@ -81,7 +101,11 @@ settings:
 	transition-property: transform, top, left;
 	transition-duration: var(--cursor-move-speed);
 	transition-timing-function: var(--cursor-move-easing);
-	border-left-width: 2px;
+	border-left-width: var(--cursor-thickness);
+}
+
+.cursor-override-color .cm-editor .cm-cursor {
+	--caret-color: var(--cursor-color);
 }
 
 .cm-cursorLayer.cm-overTableCell .cm-cursor,


### PR DESCRIPTION
Addressing issue #6 

To fix lost cursor in embedded bases, restrict transparent cursor to cm-line classes; this future-proofs a bit.

Also add settings for cursor width, and cursor color override.

Finally, tweak cm-blink-animation for better consistency with other blinking cursors.
